### PR TITLE
Prims and Dijkstra's Algorithm heapq change

### DIFF
--- a/src/chapter02recursionandbacktracking/BitSequences.py
+++ b/src/chapter02recursionandbacktracking/BitSequences.py
@@ -10,7 +10,7 @@
 
 
 def append_at_front(x, L):
-    return [x + element for element in L]
+    return [x + element for element in    L]
 
 def bit_strings(n):
     if n == 0: return []


### PR DESCRIPTION

 #add this to the vertex class, since heapq doesn't allow objects for comparisions
 def __lt__(ob1, ob2):
        return ob1.getDistance() < ob2.getDistance()

